### PR TITLE
Fix code generation for FSEvents

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -218,6 +218,9 @@ let emit_globals_prelude fw =
     (* | "corefoundation" ->
       [ "open CoreFoundation_globals" ] *)
 
+    | "fsevents" ->
+      [ "open CoreFoundation" ]
+
     | "foundation" | "corevideo" ->
       [ "[@@@ocaml.warning \"-33\"]"
       ; "open CoreFoundation"


### PR DESCRIPTION
Instead of manually editing the generated files, include the `open` automatically.

I suspect there are better/more generic fixes, but they are definitely more involved :-) 