### PR TITLE
Always ignore unused module warning in generated code

### DIFF
--- a/lib/util.ml
+++ b/lib/util.ml
@@ -134,6 +134,7 @@ let emit_doc_comment ?(search=false) fw symbol =
 
 let emit_prelude ~open_modules file =
   [ "(* auto-generated, do not modify *)\n"
+  ; "[@@@ocaml.warning \"-33\"]"
   ; "open Runtime"
   ; "open Objc"
   ]
@@ -168,8 +169,6 @@ let open_modules mod_names =
   if String.(equal mod_names empty) then
     []
   else
-    "[@@@ocaml.warning \"-33\"]"
-    ::
     (String.split_on_char ',' mod_names |> List.map ((^) "open "))
 ;;
 


### PR DESCRIPTION
Some generated globals files (e.g., [SpriteKit/SpriteKit_globals.ml](https://github.com/dboris/camlkit/blob/main/SpriteKit/SpriteKit_globals.ml) don't end up using the `Objc` module, so they require manual editing of the generated code.

This change makes it so the directive to ignore unused modules warning is unconditionally added to all generated files as part of the prelude.